### PR TITLE
improve: add marimo.app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ a = 1
 b = 2
 ```
 
-<!-- url-copy: https://python.playground.com param-name: source -->
+<!-- url-copy: https://marimo.app param-name: code -->
 ```python
 def hello_world():
     print("Hello, World!")
@@ -24,6 +24,12 @@ def hello_world():
 
 <script src="extractor.js"></script>
 ````
+
+<!-- url-copy: https://marimo.app param-name: code -->
+```python
+def hello_world():
+    print("Hello, World!")
+```
 
 Notice how the first codeblock does not have a comment but the second one does? The second codeblock will get an extra button added to it that will send the code to the specified URL as a query string.
 

--- a/docs/extractor.js
+++ b/docs/extractor.js
@@ -83,7 +83,7 @@ ${code.split('\n').map(line => '    ' + line).join('\n')}
           const encodedCode = encodeURIComponent(code);
 
           // Create the URL with the code as a query param
-          const url = `${foundConfig.url}/?${foundConfig.paramName}=${encodedCode}`;
+          const url = `${foundConfig.url}?${foundConfig.paramName}=${encodedCode}`;
 
           // Open the URL in a new tab
           window.open(url, '_blank');

--- a/docs/extractor.js
+++ b/docs/extractor.js
@@ -1,23 +1,22 @@
 document.addEventListener('DOMContentLoaded', function() {
   // Process all pre elements that contain code blocks
   const preElements = document.querySelectorAll(['pre', 'div.highlight']);
-  console.log(preElements);
   preElements.forEach(preElement => {
     // Check if there's a special comment before this pre element
     let node = preElement.previousSibling;
     let foundConfig = null;
-    
+
     // Look for HTML comments before the pre element
     while (node && !foundConfig) {
       if (node.nodeType === Node.COMMENT_NODE) {
         const commentText = node.textContent.trim();
-        
+
         // Parse our special comment format: <!-- url-copy: URL [param-name: NAME] -->
         if (commentText.startsWith('url-copy:')) {
           try {
             const regex = /url-copy:\s*([^\s]+)(?:\s+param-name:\s*([^\s]+))?/;
             const match = commentText.match(regex);
-            
+
             if (match) {
               foundConfig = {
                 url: match[1],
@@ -29,19 +28,19 @@ document.addEventListener('DOMContentLoaded', function() {
           }
         }
       }
-      
+
       node = node.previousSibling;
     }
-    
+
     // If we found a config comment, add the button
     if (foundConfig) {
       const codeElement = preElement.querySelector('code');
-      
+
       if (codeElement) {
         // Create the button
         const button = document.createElement('button');
         button.className = 'url-copy-button';
-        button.title = 'Open code in new tab';
+        button.title = 'Open code in an interactive playground';
         button.style.position = 'absolute';
         button.style.top = '0.5rem';
         button.style.right = '0.5rem';
@@ -60,24 +59,36 @@ document.addEventListener('DOMContentLoaded', function() {
 
         button.addEventListener("mouseover", function() { button.style.filter = "grayscale(0%)"; });
         button.addEventListener("mouseout", function() { button.style.filter = 'grayscale(100%)'; });
-        
+
         // Add click event to the button
         button.addEventListener('click', function(e) {
           e.preventDefault();
-          
+
           // Get the code text
-          const code = codeElement.textContent;
-          
+          let code = codeElement.textContent;
+
+          if (foundConfig.url.indexOf("marimo.app") >= 0) {
+            // Wrap the code block in marimo notebook boilerplate
+            code = `import marimo
+
+app = marimo.App()
+
+@app.cell
+def _():
+${code.split('\n').map(line => '    ' + line).join('\n')}
+`;
+          }
+
           // Encode the code for use in a URL
           const encodedCode = encodeURIComponent(code);
-          
+
           // Create the URL with the code as a query param
-          const url = `${foundConfig.url}?${foundConfig.paramName}=${encodedCode}`;
-          
+          const url = `${foundConfig.url}/?${foundConfig.paramName}=${encodedCode}`;
+
           // Open the URL in a new tab
           window.open(url, '_blank');
         });
-        
+
         // Add the button to the pre element
         preElement.appendChild(button);
       }

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,12 @@ a = 1
 b = 2
 ```
 
-<!-- url-copy: https://python.playground.com param-name: source -->
+<!-- url-copy: https://marimo.app param-name: code -->
 ```python
 def hello_world():
     print("Hello, World!")
+
+hello_world()
 ```
 
 <script src="extractor.js"></script>


### PR DESCRIPTION
This PR adds support for opening code blocks in marimo notebooks.

If `url-copy` contains `marimo.app`, the extractor wraps the code block in marimo boilerplate before encoding it.

@koaning 